### PR TITLE
Fix Deface precompilation with config.deface.disabled = true

### DIFF
--- a/lib/spree_comments/engine.rb
+++ b/lib/spree_comments/engine.rb
@@ -13,10 +13,6 @@ module SpreeComments
       Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|
         Rails.application.config.cache_classes ? require(c) : load(c)
       end
-
-      Dir.glob(File.join(File.dirname(__FILE__), "../../app/overrides/*.rb")) do |c|
-        Rails.application.config.cache_classes ? require(c) : load(c)
-      end
     end
 
     config.to_prepare &method(:activate).to_proc


### PR DESCRIPTION
Hey

Manual override requires are no longer required and issue warnings in Deface. 
