### PR TITLE
Remove old unused shipment overrides

### DIFF
--- a/app/overrides/add_shipment_comment_button.rb
+++ b/app/overrides/add_shipment_comment_button.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/admin/shipments/edit",
-                     :name => "converted_admin_shipment_edit_buttons_233418828",
-                     :insert_after => "code[erb-silent]:contains('content_for :page_actions')",
-                     :partial => "spree/admin/shipments/button",
-                     :disabled => false)

--- a/app/views/spree/admin/shipments/_button.html.erb
+++ b/app/views/spree/admin/shipments/_button.html.erb
@@ -1,4 +1,0 @@
-<li>
-  <%= button_link_to Spree.t(:comments), comments_admin_order_shipment_url(@order, @shipment) %>
-</li>
-


### PR DESCRIPTION
this removes an unused override, it doesn't work and it's not useful anymore since shipments are inside order edit and not on their own page, should be merge on 2-0-stable, 2-1-stable, and master
