### PR TITLE
[2-1-stable] New syntax to remove 'DEPRECATION WARNING: Calling #scope o...

### DIFF
--- a/app/models/spree/comment.rb
+++ b/app/models/spree/comment.rb
@@ -4,7 +4,7 @@ class Spree::Comment < ActiveRecord::Base
   belongs_to :commentable, :polymorphic => true
   belongs_to :comment_type
 
-  default_scope :order => 'created_at ASC'
+  default_scope { order('created_at ASC') }
 
   # NOTE: install the acts_as_votable plugin if you
   # want user to vote on the quality of comments.


### PR DESCRIPTION
...r #default_scope with a hash is deprecated' for Rails 4
