### PR TITLE
Bump Spree dependency to 2.4.x

### DIFF
--- a/spree_comments.gemspec
+++ b/spree_comments.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path  = 'lib'
   s.requirements << 'none'
 
-  spree_version = '~> 2.4.0.beta'
+  spree_version = '~> 2.4.0'
   s.add_dependency 'spree_api', spree_version
   s.add_dependency 'spree_backend', spree_version
   s.add_dependency 'spree_core', spree_version


### PR DESCRIPTION
Merge this into a new 2-4-stable branch.