### PR TITLE
Bugfix for Spree 3.7 on Rails 5

### DIFF
--- a/app/controllers/spree/admin/comments_controller.rb
+++ b/app/controllers/spree/admin/comments_controller.rb
@@ -2,7 +2,7 @@ class Spree::Admin::CommentsController < Spree::Admin::ResourceController
   private
 
   def location_after_save
-    # :back is not deprecated in Rails 5, but request.referrer should also work as intended on older versions (confirmed to work on Rails 4 and 5)
+    # :back is deprecated in Rails 5, but request.referrer should also work as intended on older versions (confirmed to work on Rails 4 and 5)
     request.referrer
   end
 

--- a/app/controllers/spree/admin/comments_controller.rb
+++ b/app/controllers/spree/admin/comments_controller.rb
@@ -1,7 +1,9 @@
 class Spree::Admin::CommentsController < Spree::Admin::ResourceController
   private
-  
+
   def location_after_save
-    :back
+    # :back is not deprecated in Rails 5, but request.referrer should also work as intended on older versions (confirmed to work on Rails 4 and 5)
+    request.referrer
   end
+
 end

--- a/app/overrides/add_comment_configuration.rb
+++ b/app/overrides/add_comment_configuration.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/admin/shared/sub_menu/_configuration",
                      :name => "converted_admin_configurations_menu_468573024",
                      :insert_bottom => "[data-hook='admin_configurations_sidebar_menu']",
-                     :text => "<%= configurations_sidebar_menu_item Spree.t(:comment_types), admin_comment_types_path %>",
+                     :text => "<%- if spree_current_user.admin? %><%= configurations_sidebar_menu_item Spree.t(:comment_types), admin_comment_types_path %><% end %>",
                      :disabled => false)


### PR DESCRIPTION
When creating a comment on Spree 3.7.0 and Rails 5.2.3, you will receive a :back method not found error from the location_after_save method in the admin/comments_controller.rb because :back was deprecated in Rails 5.

Changing the :back method to a more universal way of getting back to the last page (request.referrer) cleared up the issue. This should also work for previous versions of Rails before the :back method was deprecated.